### PR TITLE
Make taxonomies show in editor WP5.3 change

### DIFF
--- a/inc/custom-taxonomies.php
+++ b/inc/custom-taxonomies.php
@@ -29,6 +29,7 @@ function fl_add_futurelab_teams() {
 		'labels'            => $labels,
 		'show_ui'           => true,
 		'show_admin_column' => true,
+		'show_in_rest'      => true,
 		'query_var'         => true,
 		'rewrite'           => array( 'slug' => 'teams' )
 	);
@@ -59,6 +60,7 @@ function fl_add_futurelab_service_category() {
 		'show_ui'           => true,
 		'show_admin_column' => true,
 		'query_var'         => true,
+		'show_in_rest'      => true,
 		'rewrite'           => array( 'slug' => 'services' )
 	);
 


### PR DESCRIPTION
For some reason WP5.3 no longer takes show_in_rest from ui settings, so taxonomy selections have dropped off in Gutenberg without it